### PR TITLE
Add UiColor system to plugin

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -23,6 +23,8 @@ impl Plugin for EasingsPlugin {
         app.add_system(ease_system::<Sprite>.system());
         #[cfg(feature = "ui")]
         app.add_system(ease_system::<Style>.system());
+        #[cfg(feature = "ui")]
+        app.add_system(ease_system::<UiColor>.system());
     }
 }
 


### PR DESCRIPTION
Currently the `ui_color` example is broken because UiColor easings are not registered by the plugin. This PR registers the UiColor component to be eased.