### PR TITLE
Add bevy/x11 feature for running examples on linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default = ["render", "sprite", "ui"]
 "render" = ["bevy/bevy_render"]
 "sprite" = ["bevy/bevy_sprite"]
 "ui" = ["bevy/bevy_ui"]
-"examples" = ["ui", "sprite", "render", "bevy/render", "bevy/bevy_winit"]
+"examples" = ["ui", "sprite", "render", "bevy/render", "bevy/bevy_winit", "bevy/x11"]
 
 [[example]]
 name = "chain"


### PR DESCRIPTION
Winit requires either the `x11` or `wayland` feature to run on Linux. This PR adds the `x11` feature for examples.