### PR TITLE
Add public accessor for EasingComponent.direction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,15 @@ pub struct EasingComponent<T> {
     direction: i16,
 }
 
+impl<T> EasingComponent<T> {
+    /// For [EasingType::PingPong], gets the current direction as -1 or 1.
+    ///
+    /// Positive is in the direction of the "ping" (first iteration).
+    pub fn direction(&self) -> i16 {
+        self.direction
+    }
+}
+
 impl<T: std::fmt::Debug> std::fmt::Debug for EasingComponent<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EasingComponent")


### PR DESCRIPTION
A "nice to have" piece of info for ping pong easings where the calling context wants to adapt its behaviors to what direction the easing is going in.

See for instance a [doppler factor calculation](https://github.com/dtaralla/bevy-rrise/blob/main/examples/doppler_drone.rs#L68) based on the movement introduced by this crate.