### PR TITLE
fix: replace early return with continue in ease system

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -42,7 +42,7 @@ pub fn ease_system<T: Ease + Component>(
             if easing.state == EasingState::Play {
                 easing.timer.tick(time.delta());
             } else {
-                return;
+                continue;
             }
             if easing.paused {
                 if easing.timer.just_finished() {


### PR DESCRIPTION
This fixes an issue in the main ease_system loop where if one easing is paused then all other easings at a later index in the query iterator don't get updated because we are returning instead of continuing.