### PR TITLE
method to avoid code duplication with initial component value

### DIFF
--- a/examples/custom_component.rs
+++ b/examples/custom_component.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[derive(Default, Component)]
+#[derive(Default, Component, Clone)]
 struct CustomComponent(f32);
 impl bevy_easings::Lerp for CustomComponent {
     type Scalar = f32;
@@ -44,17 +44,19 @@ fn setup(mut commands: Commands) {
             background_color: BackgroundColor(Color::RED),
             ..Default::default()
         },
-        // as `CustomComponent` is not already part of the components of the entity,
-        // insert the component with a basic value, it will be replaced immediately
-        CustomComponent(-1.),
-        CustomComponent(0.).ease_to(
-            CustomComponent(100.),
-            bevy_easings::EaseFunction::QuadraticInOut,
-            bevy_easings::EasingType::PingPong {
-                duration: std::time::Duration::from_secs(1),
-                pause: Some(std::time::Duration::from_millis(500)),
-            },
-        ),
+        CustomComponent(0.)
+            .ease_to(
+                CustomComponent(100.),
+                bevy_easings::EaseFunction::QuadraticInOut,
+                bevy_easings::EasingType::PingPong {
+                    duration: std::time::Duration::from_secs(1),
+                    pause: Some(std::time::Duration::from_millis(500)),
+                },
+            )
+            // as `CustomComponent` is not already part of the components of the entity,
+            // we can either insert the component with a basic value, it will be replaced immediately,
+            // or call `with_original_value` if the `CustomComponent` implements `Clone`
+            .with_original_value(),
     ));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,18 @@ impl<T> EasingComponent<T> {
     }
 }
 
+impl<T> EasingComponent<T>
+where
+    T: Clone,
+{
+    /// Returns a bundle containing the starting value additionally to this [EasingComponent].
+    pub fn with_original_value(self) -> (T, Self) {
+        let starting_value = self.start.clone().unwrap().0;
+
+        (starting_value, self)
+    }
+}
+
 impl<T: std::fmt::Debug> std::fmt::Debug for EasingComponent<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EasingComponent")


### PR DESCRIPTION
I found it a bit counterintuitive to be forced to add a "placeholder" component only to have it "replaced immediately", so I did a helper function to help with that.

It might not be worth the added cognitive load of an additional function hiding "complexity", but this pattern has helped me with bigger components where in practice I had to declare it above the spawn, then clone it, or implement default.