### PR TITLE
chore: release v0.17.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_easings"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 edition = "2024"
 description = "Easing plugin for Bevy"


### PR DESCRIPTION



## 🤖 New release

* `bevy_easings`: 0.17.0 -> 0.17.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).